### PR TITLE
Add workspace skeleton with Next.js and FastAPI

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,23 @@
+name: Backup Data
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: zip -r data.zip data
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - run: aws s3 cp data.zip s3://$OBSIDIAN_BACKUP/$(date +%F).zip
+        env:
+          OBSIDIAN_BACKUP: ${{ secrets.OBSIDIAN_BACKUP }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/universal:2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# personal
+# Personal Workspace
+
+This repo contains a minimal template for a Codespaces-ready project using Next.js and FastAPI.
+
+## Getting Started
+
+```bash
+npm run dev     # start Next.js on port 3000
+npm run api     # start FastAPI on port 8000
+```

--- a/api/journal.py
+++ b/api/journal.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from datetime import date
+import json
+from pathlib import Path
+
+router = APIRouter()
+DB_FILE = Path('data/site.db')
+DB_FILE.parent.mkdir(exist_ok=True)
+
+class Entry(BaseModel):
+    answers: list[str]
+
+@router.post('/journal', status_code=201)
+def add_entry(entry: Entry):
+    day = date.today().isoformat()
+    md_path = Path('data/journal')
+    md_path.mkdir(parents=True, exist_ok=True)
+    md_file = md_path / f"{day}.md"
+    with md_file.open('w') as f:
+        f.write('\n'.join(entry.answers))
+    return {'ok': True}

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from .journal import router as journal_router
+
+app = FastAPI()
+app.include_router(journal_router)
+
+@app.get('/ping')
+def ping():
+    return {'ping': 'pong'}

--- a/app/habits/page.tsx
+++ b/app/habits/page.tsx
@@ -1,0 +1,3 @@
+export default function Habits() {
+  return <p>Habits page</p>
+}

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+const questions = [
+  'How did you feel?',
+  'Big win?',
+  'What did you learn?',
+  'Challenges?',
+  'Anything else?'
+]
+
+export default function Journal() {
+  const [answers, setAnswers] = useState<string[]>(Array(5).fill(''))
+  const handleChange = (idx: number, val: string) => {
+    const copy = [...answers]
+    copy[idx] = val
+    setAnswers(copy)
+  }
+  const handleSubmit = async () => {
+    await fetch('/api/journal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers })
+    })
+    setAnswers(Array(5).fill(''))
+    alert('Saved')
+  }
+  return (
+    <div className="space-y-2">
+      {questions.map((q, i) => (
+        <div key={i}>
+          <label className="block font-bold mb-1">{q}</label>
+          <input
+            className="border p-2 w-full"
+            value={answers[i]}
+            onChange={(e) => handleChange(i, e.target.value)}
+          />
+        </div>
+      ))}
+      <button onClick={handleSubmit} className="px-4 py-2 bg-blue-500 text-white">Save</button>
+    </div>
+  )
+}

--- a/app/knowledge/page.tsx
+++ b/app/knowledge/page.tsx
@@ -1,0 +1,3 @@
+export default function Knowledge() {
+  return <p>Knowledge page</p>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import './globals.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Workspace',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="p-4">
+        <nav className="flex space-x-4 mb-4">
+          <Link href="/journal">Journal</Link>
+          <Link href="/habits">Habits</Link>
+          <Link href="/knowledge">Knowledge</Link>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Welcome</p>
+}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "journalsite",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "postCreateCommand": "pip install fastapi uvicorn python-dotenv && npm i",
+  "forwardPorts": [3000, 8000]
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="next" />\n/// <reference types="next/image-types/global" />\n/// <reference types="next/navigation-types/compat/navigation" />\n

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "personal",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next dev",
+    "api": "uvicorn api.main:app --reload"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js frontend with Tailwind
- add FastAPI backend with journal route
- configure Codespaces via devcontainer
- Dockerfile placeholder
- nightly backup workflow

## Testing
- `pytest -q` *(fails: command not found)*